### PR TITLE
Enable nullable reference types

### DIFF
--- a/geometry3Sharp.csproj
+++ b/geometry3Sharp.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
## Summary
- turn on nullable reference types in geometry3Sharp.csproj

## Testing
- `xbuild geometry3Sharp.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6843fb782988832bbe8dfe06ba957cc8