### PR TITLE
Fix BlockCount and expose BlockSize

### DIFF
--- a/core/DVector.cs
+++ b/core/DVector.cs
@@ -66,7 +66,17 @@ namespace g3
             get { return iCurBlock * nBlockSize + iCurBlockUsed;  }
         }
 
+        /// <summary>
+        /// Number of blocks currently allocated in this vector
+        /// </summary>
         public int BlockCount {
+            get { return Blocks.Count; }
+        }
+
+        /// <summary>
+        /// Size of each block in this vector
+        /// </summary>
+        public int BlockSize {
             get { return nBlockSize; }
         }
 

--- a/io/gSerialization.cs
+++ b/io/gSerialization.cs
@@ -458,7 +458,7 @@ namespace g3
         // [TODO] these could be a lot faster if DVector had a block-iterator...
         public static void Store(DVector<double> vec, BinaryWriter writer)
         {
-            byte[] buffer = new byte[vec.BlockCount * sizeof(double)];
+            byte[] buffer = new byte[vec.BlockSize * sizeof(double)];
             int N = vec.Length;
             writer.Write(N);
             foreach ( DVector<double>.DBlock block in vec.BlockIterator() ) {
@@ -477,7 +477,7 @@ namespace g3
 
         public static void Store(DVector<float> vec, BinaryWriter writer)
         {
-            byte[] buffer = new byte[vec.BlockCount * sizeof(float)];
+            byte[] buffer = new byte[vec.BlockSize * sizeof(float)];
             int N = vec.Length;
             writer.Write(N);
             foreach ( DVector<float>.DBlock block in vec.BlockIterator() ) {
@@ -496,7 +496,7 @@ namespace g3
 
         public static void Store(DVector<int> vec, BinaryWriter writer)
         {
-            byte[] buffer = new byte[vec.BlockCount * sizeof(int)];
+            byte[] buffer = new byte[vec.BlockSize * sizeof(int)];
             int N = vec.Length;
             writer.Write(N);
             foreach ( DVector<int>.DBlock block in vec.BlockIterator() ) {
@@ -515,7 +515,7 @@ namespace g3
 
         public static void Store(DVector<short> vec, BinaryWriter writer)
         {
-            byte[] buffer = new byte[vec.BlockCount * sizeof(short)];
+            byte[] buffer = new byte[vec.BlockSize * sizeof(short)];
             int N = vec.Length;
             writer.Write(N);
             foreach ( DVector<short>.DBlock block in vec.BlockIterator() ) {


### PR DESCRIPTION
## Summary
- change `BlockCount` to return the number of blocks
- add `BlockSize` property exposing `nBlockSize`
- update serialization helpers to use `BlockSize`

## Testing
- `dotnet build geometry3Sharp_netstandard.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6843d6a702d0832bad893efac02e9c3e