### PR TITLE
Implement curve sampling and 1D bounding box

### DIFF
--- a/containment/ContMinBox2.cs
+++ b/containment/ContMinBox2.cs
@@ -51,19 +51,26 @@ namespace g3
                 }
 
                 if (hullDim == 1) {
-                    throw new NotImplementedException("ContMinBox2: Have not implemented 1d case");
-                    //ConvexHull1 hull1 = hull.GetConvexHull1();
-                    //hullIndices = hull1->GetIndices();
+                    Vector2d origin, dir;
+                    hull.Get1DHullInfo(out origin, out dir);
+                    double min = double.MaxValue, max = double.MinValue;
+                    for (int i = 0; i < points.Count; ++i) {
+                        double t = dir.Dot(points[i] - origin);
+                        if (t < min) min = t;
+                        if (t > max) max = t;
+                    }
 
-                    //mMinBox.Center = ((double)0.5) * (points[hullIndices[0]] +
-                    //    points[hullIndices[1]]);
-                    //Vector2d diff =
-                    //    points[hullIndices[1]] - points[hullIndices[0]];
-                    //mMinBox.Extent[0] = ((double)0.5) * diff.Normalize();
-                    //mMinBox.Extent[1] = (double)0.0;
-                    //mMinBox.Axis[0] = diff;
-                    //mMinBox.Axis[1] = -mMinBox.Axis[0].Perp();
-                    //return;
+                    Vector2d axis0 = dir;
+                    axis0.Normalize();
+                    Vector2d axis1 = -axis0.Perp;
+
+                    double extent0 = 0.5 * (max - min);
+                    mMinBox.Center = origin + 0.5 * (min + max) * axis0;
+                    mMinBox.AxisX = axis0;
+                    mMinBox.AxisY = axis1;
+                    mMinBox.Extent[0] = extent0;
+                    mMinBox.Extent[1] = 0;
+                    return;
                 }
 
                 numPoints = hullNumSimplices;

--- a/curve/PolyLine2d.cs
+++ b/curve/PolyLine2d.cs
@@ -404,7 +404,14 @@ namespace g3
         }
         public Vector2d TangentT(double t)
         {
-            throw new NotImplementedException("Polygon2dCurve.TangentT");
+            if (Polyline.VertexCount < 2)
+                return Vector2d.Zero;
+            int i = (int)t;
+            if (i >= Polyline.VertexCount - 1)
+                i = Polyline.VertexCount - 2;
+            Vector2d a = Polyline[i];
+            Vector2d b = Polyline[i + 1];
+            return (b - a).Normalized;
         }
 
         public bool HasArcLength { get { return true; } }
@@ -414,7 +421,29 @@ namespace g3
 
         public Vector2d SampleArcLength(double a)
         {
-            throw new NotImplementedException("Polygon2dCurve.SampleArcLength");
+            if (Polyline.VertexCount == 0)
+                return Vector2d.Zero;
+
+            if (a <= 0)
+                return Polyline[0];
+
+            double length = Polyline.ArcLength;
+            if (a >= length)
+                return Polyline[Polyline.VertexCount - 1];
+
+            double accum = 0;
+            for (int i = 0; i < Polyline.VertexCount - 1; ++i) {
+                Vector2d v0 = Polyline[i];
+                Vector2d v1 = Polyline[i + 1];
+                double segLen = v0.Distance(v1);
+                if (a <= accum + segLen) {
+                    double t = (a - accum) / segLen;
+                    return (1 - t) * v0 + t * v1;
+                }
+                accum += segLen;
+            }
+
+            return Polyline[Polyline.VertexCount - 1];
         }
 
         public void Reverse()

--- a/curve/Polygon2d.cs
+++ b/curve/Polygon2d.cs
@@ -813,14 +813,40 @@ namespace g3
         }
         public Vector2d TangentT(double t)
         {
-            throw new NotImplementedException("Polygon2dCurve.TangentT");
+            int i = (int)t;
+            if (Polygon.VertexCount < 2)
+                return Vector2d.Zero;
+            if (i >= Polygon.VertexCount)
+                i = Polygon.VertexCount - 1;
+            return Polygon.GetTangent(i % Polygon.VertexCount);
         }
 
         public bool HasArcLength { get { return true; } }
         public double ArcLength { get { return Polygon.ArcLength; } }
         public Vector2d SampleArcLength(double a)
         {
-            throw new NotImplementedException("Polygon2dCurve.SampleArcLength");
+            if (Polygon.VertexCount == 0)
+                return Vector2d.Zero;
+
+            double length = Polygon.ArcLength;
+            if (length <= MathUtil.ZeroTolerance)
+                return Polygon[0];
+
+            a = MathUtil.Clamp(a, 0, length);
+
+            double accum = 0;
+            for (int i = 0; i < Polygon.VertexCount; ++i) {
+                Vector2d v0 = Polygon[i];
+                Vector2d v1 = Polygon[(i + 1) % Polygon.VertexCount];
+                double segLen = v0.Distance(v1);
+                if (a <= accum + segLen) {
+                    double t = (a - accum) / segLen;
+                    return (1 - t) * v0 + t * v1;
+                }
+                accum += segLen;
+            }
+
+            return Polygon[Polygon.VertexCount - 1];
         }
 
         public void Reverse()


### PR DESCRIPTION
## Summary
- handle 1D case in `ContMinBox2`
- implement tangent and arc length sampling for `PolyLine2DCurve`
- implement tangent and arc length sampling for `Polygon2DCurve`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684426b94278832b801610a80da623ee