### PR TITLE
Fix Bitmap3 cloning and add tests

### DIFF
--- a/geometry3Sharp.Tests/Bitmap3Tests.cs
+++ b/geometry3Sharp.Tests/Bitmap3Tests.cs
@@ -1,0 +1,27 @@
+using NUnit.Framework;
+using g3;
+
+namespace geometry3Sharp.Tests
+{
+    public class Bitmap3Tests
+    {
+        [Test]
+        public void ClonePreservesBits()
+        {
+            var bmp = new Bitmap3(new Vector3i(3, 3, 3));
+            bmp[new Vector3i(0, 0, 0)] = true;
+            bmp[new Vector3i(1, 2, 1)] = true;
+            bmp[new Vector3i(2, 1, 2)] = true;
+
+            var clone = bmp.CreateNewGridElement(true) as Bitmap3;
+            Assert.NotNull(clone, "Clone returned null");
+
+            foreach (Vector3i idx in bmp.Indices())
+            {
+                Assert.That(clone[idx], Is.EqualTo(bmp[idx]), $"Mismatch at {idx}");
+            }
+
+            Assert.False(ReferenceEquals(bmp.Bits, clone.Bits), "Clone should have independent BitArray");
+        }
+    }
+}

--- a/geometry3Sharp.Tests/geometry3Sharp.Tests.csproj
+++ b/geometry3Sharp.Tests/geometry3Sharp.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="NUnit.Framework" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\geometry3Sharp_netstandard.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/geometry3Sharp_netstandard.csproj
+++ b/geometry3Sharp_netstandard.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <Compile Remove="Properties\AssemblyInfo.cs" />
+    <Compile Remove="geometry3Sharp.Tests\**" />
   </ItemGroup>
 
   <ItemGroup>

--- a/spatial/Bitmap3.cs
+++ b/spatial/Bitmap3.cs
@@ -152,7 +152,9 @@ namespace g3
         {
             Bitmap3 copy = new Bitmap3(Dimensions);
             if (bCopy)
-                throw new NotImplementedException();
+            {
+                copy.Bits = new BitArray(this.Bits);
+            }
             return copy;
         }
 


### PR DESCRIPTION
## Summary
- implement bit array copying for Bitmap3.CreateNewGridElement
- exclude tests folder from main project compilation
- add NUnit test project to verify cloning

## Testing
- `dotnet test geometry3Sharp.Tests/geometry3Sharp.Tests.csproj --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6846e3c283e4832ba034a96089afc5de