### PR TITLE
Implement EdgeSpan span comparison

### DIFF
--- a/geometry3Sharp_netstandard.csproj
+++ b/geometry3Sharp_netstandard.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <Compile Remove="Properties\AssemblyInfo.cs" />
+    <Compile Remove="tests\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/mesh/EdgeSpan.cs
+++ b/mesh/EdgeSpan.cs
@@ -181,9 +181,44 @@ namespace g3
         // Does not require the indexing to be the same
         public bool IsSameSpan(EdgeSpan Spanw, bool bReverse2 = false, double tolerance = MathUtil.ZeroTolerance)
         {
-			// [RMS] this is much easier than for a loop, because it has to have 
-			//   same endpoints. But don't have time right now.
-			throw new NotImplementedException("todo!");
+            int N = Vertices.Length;
+            if (Spanw.Vertices.Length != N || Spanw.Edges.Length != Edges.Length)
+                return false;
+
+            DMesh3 mesh2 = Spanw.Mesh;
+
+            for (int i = 0; i < N; ++i) {
+                int j = (bReverse2) ? (N - 1 - i) : i;
+                Vector3d v1 = Mesh.GetVertex(Vertices[i]);
+                Vector3d v2 = mesh2.GetVertex(Spanw.Vertices[j]);
+                if (v1.Distance(v2) > tolerance)
+                    return false;
+            }
+
+            int M = Edges.Length;
+            for (int i = 0; i < M; ++i) {
+                int j = (bReverse2) ? (M - 1 - i) : i;
+                Index2i e1 = Mesh.GetEdgeV(Edges[i]);
+                Index2i e2 = mesh2.GetEdgeV(Spanw.Edges[j]);
+
+                Vector3d e1a = Mesh.GetVertex(e1.a);
+                Vector3d e1b = Mesh.GetVertex(e1.b);
+                Vector3d e2a = mesh2.GetVertex(e2.a);
+                Vector3d e2b = mesh2.GetVertex(e2.b);
+
+                bool sameDir = (e1a.Distance(e2a) <= tolerance && e1b.Distance(e2b) <= tolerance);
+                bool oppDir  = (e1a.Distance(e2b) <= tolerance && e1b.Distance(e2a) <= tolerance);
+
+                if (bReverse2) {
+                    if (!oppDir && !sameDir)
+                        return false;
+                } else {
+                    if (!sameDir && !oppDir)
+                        return false;
+                }
+            }
+
+            return true;
         }
 
 

--- a/tests/Geometry3Sharp.Tests/EdgeSpanTests.cs
+++ b/tests/Geometry3Sharp.Tests/EdgeSpanTests.cs
@@ -1,0 +1,41 @@
+using g3;
+using NUnit.Framework;
+
+namespace Geometry3Sharp.Tests;
+
+[TestFixture]
+public class EdgeSpanTests
+{
+    private DMesh3 CreateLineMesh()
+    {
+        DMesh3 mesh = new DMesh3();
+        int v0 = mesh.AppendVertex(new Vector3d(0, 0, 0));
+        int v1 = mesh.AppendVertex(new Vector3d(1, 0, 0));
+        int v2 = mesh.AppendVertex(new Vector3d(2, 0, 0));
+        int v3 = mesh.AppendVertex(new Vector3d(0, 1, 0));
+        mesh.AppendTriangle(v0, v1, v3);
+        mesh.AppendTriangle(v1, v2, v3);
+        return mesh;
+    }
+
+    [Test]
+    public void IsSameSpan_Identical()
+    {
+        DMesh3 mesh1 = CreateLineMesh();
+        var span1 = EdgeSpan.FromVertices(mesh1, new int[] { 0, 1, 2 });
+        DMesh3 mesh2 = CreateLineMesh();
+        var span2 = EdgeSpan.FromVertices(mesh2, new int[] { 0, 1, 2 });
+        Assert.True(span1.IsSameSpan(span2));
+    }
+
+    [Test]
+    public void IsSameSpan_Reversed()
+    {
+        DMesh3 mesh1 = CreateLineMesh();
+        var span1 = EdgeSpan.FromVertices(mesh1, new int[] { 0, 1, 2 });
+        DMesh3 mesh2 = CreateLineMesh();
+        var span2 = EdgeSpan.FromVertices(mesh2, new int[] { 2, 1, 0 });
+        Assert.True(span1.IsSameSpan(span2, bReverse2: true));
+        Assert.False(span1.IsSameSpan(span2));
+    }
+}

--- a/tests/Geometry3Sharp.Tests/Geometry3Sharp.Tests.csproj
+++ b/tests/Geometry3Sharp.Tests/Geometry3Sharp.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\geometry3Sharp_netstandard.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="NUnit.Framework" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- implement `EdgeSpan.IsSameSpan`
- migrate tests to NUnit framework
- verify identical and reversed edge spans
- exclude tests from library build

## Testing
- `dotnet test tests/Geometry3Sharp.Tests/Geometry3Sharp.Tests.csproj --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6846e3c7b5c4832bbc72988d31f9efbc