### PR TITLE
Enable binary OBJ writing

### DIFF
--- a/geometry3Sharp_netstandard.csproj
+++ b/geometry3Sharp_netstandard.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <Compile Remove="Properties\AssemblyInfo.cs" />
+    <Compile Remove="tests\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/io/OBJWriter.cs
+++ b/io/OBJWriter.cs
@@ -28,8 +28,16 @@ namespace g3
 
         public IOWriteResult Write(BinaryWriter writer, List<WriteMesh> vMeshes, WriteOptions options)
         {
-            // [RMS] not supported
-            throw new NotImplementedException();
+            // Write ASCII OBJ data to provided binary writer by wrapping the
+            // underlying stream with a StreamWriter. This mirrors the logic of
+            // the text writer so that material handling and indexing behave the
+            // same for binary streams.
+
+            // use ASCII encoding to match text writer behaviour
+            var sw = new StreamWriter(writer.BaseStream, Encoding.ASCII, 1024, true);
+            var result = Write(sw, vMeshes, options);
+            sw.Flush();
+            return result;
         }
 
         public IOWriteResult Write(TextWriter writer, List<WriteMesh> vMeshes, WriteOptions options)

--- a/tests/Geometry3Sharp.Tests/Geometry3Sharp.Tests.csproj
+++ b/tests/Geometry3Sharp.Tests/Geometry3Sharp.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\geometry3Sharp_netstandard.csproj" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+  </ItemGroup>
+</Project>

--- a/tests/Geometry3Sharp.Tests/OBJWriterBinaryTests.cs
+++ b/tests/Geometry3Sharp.Tests/OBJWriterBinaryTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Collections.Generic;
+using Xunit;
+
+namespace g3.Tests
+{
+    public class OBJWriterBinaryTests
+    {
+        private string WriteText(WriteMesh mesh, WriteOptions options, OBJWriter writer)
+        {
+            var sw = new StringWriter();
+            writer.Write(sw, new List<WriteMesh>{mesh}, options);
+            return sw.ToString();
+        }
+
+        private byte[] WriteBinary(WriteMesh mesh, WriteOptions options, OBJWriter writer)
+        {
+            using (var ms = new MemoryStream())
+            {
+                using (var bw = new BinaryWriter(ms, Encoding.ASCII, true))
+                {
+                    writer.Write(bw, new List<WriteMesh>{mesh}, options);
+                    bw.Flush();
+                }
+                return ms.ToArray();
+            }
+        }
+
+        [Fact]
+        public void BasicWriteMatchesText()
+        {
+            var mesh = new DMesh3();
+            int v0 = mesh.AppendVertex(new Vector3d(0,0,0));
+            int v1 = mesh.AppendVertex(new Vector3d(1,0,0));
+            int v2 = mesh.AppendVertex(new Vector3d(0,1,0));
+            mesh.AppendTriangle(v0, v1, v2);
+
+            var wmesh = new WriteMesh(mesh);
+            var opts = WriteOptions.Defaults;
+
+            var writer = new OBJWriter();
+            string text = WriteText(wmesh, opts, writer);
+            byte[] expected = Encoding.ASCII.GetBytes(text);
+            byte[] actual = WriteBinary(wmesh, opts, writer);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void MaterialsAreWritten()
+        {
+            var mesh = new DMesh3();
+            int v0 = mesh.AppendVertex(new Vector3d(0,0,0));
+            int v1 = mesh.AppendVertex(new Vector3d(1,0,0));
+            int v2 = mesh.AppendVertex(new Vector3d(0,1,0));
+            int v3 = mesh.AppendVertex(new Vector3d(0,0,1));
+            mesh.AppendTriangle(v0, v1, v2); // t0
+            mesh.AppendTriangle(v0, v2, v3); // t1
+
+            var wmesh = new WriteMesh(mesh);
+            wmesh.Materials = new List<GenericMaterial>{ new OBJMaterial{ name="m1" }, new OBJMaterial{ name="m2" }};
+            var map = new IndexMap(false, mesh.TriangleCount);
+            map[0] = 0;
+            map[1] = 1;
+            wmesh.TriToMaterialMap = map;
+
+            var opts = WriteOptions.Defaults;
+            opts.bWriteMaterials = true;
+            opts.MaterialFilePath = "dummy.mtl";
+
+            var writer = new OBJWriter();
+            writer.OpenStreamF = (s) => new MemoryStream();
+            writer.CloseStreamF = (s) => s.Dispose();
+
+            string text = WriteText(wmesh, opts, writer);
+            byte[] expected = Encoding.ASCII.GetBytes(text);
+            byte[] actual = WriteBinary(wmesh, opts, writer);
+            Assert.Equal(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement binary OBJ stream writer by wrapping the base stream
- exclude test sources from the main build
- add xUnit test project
- verify OBJWriter binary output matches text output, with and without materials

## Testing
- `dotnet test tests/Geometry3Sharp.Tests/Geometry3Sharp.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6846e3c671ac832b94e127306df16f8f