### PR TITLE
Add CI badge and unify NUnit usage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: .NET
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+    - name: Restore
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Test
+      run: |
+        dotnet test tests/geometry3Sharp.Tests.csproj --no-build --verbosity normal
+        dotnet test tests/Geometry3Sharp.Tests/Geometry3Sharp.Tests.csproj --no-build --verbosity normal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # geometry3Sharp
+[![.NET](https://github.com/gradientspace/geometry3Sharp/actions/workflows/tests.yml/badge.svg)](https://github.com/gradientspace/geometry3Sharp/actions/workflows/tests.yml)
 
 Open-Source (Boost-license) C# library for geometric computing. 
 

--- a/geometry3Sharp_netstandard.csproj
+++ b/geometry3Sharp_netstandard.csproj
@@ -36,6 +36,7 @@
 
 
     <Compile Remove="geometry3Sharp.Tests\**\*.cs" />
+    <Compile Remove="tests\**\*.cs" />
 
 
   </ItemGroup>

--- a/tests/Geometry3Sharp.Tests/OBJWriterBinaryTests.cs
+++ b/tests/Geometry3Sharp.Tests/OBJWriterBinaryTests.cs
@@ -2,10 +2,11 @@ using System;
 using System.IO;
 using System.Text;
 using System.Collections.Generic;
-using Xunit;
+using NUnit.Framework;
 
 namespace g3.Tests
 {
+    [TestFixture]
     public class OBJWriterBinaryTests
     {
         private string WriteText(WriteMesh mesh, WriteOptions options, OBJWriter writer)
@@ -28,7 +29,7 @@ namespace g3.Tests
             }
         }
 
-        [Fact]
+        [Test]
         public void BasicWriteMatchesText()
         {
             var mesh = new DMesh3();
@@ -44,10 +45,10 @@ namespace g3.Tests
             string text = WriteText(wmesh, opts, writer);
             byte[] expected = Encoding.ASCII.GetBytes(text);
             byte[] actual = WriteBinary(wmesh, opts, writer);
-            Assert.Equal(expected, actual);
+            Assert.AreEqual(expected, actual);
         }
 
-        [Fact]
+        [Test]
         public void MaterialsAreWritten()
         {
             var mesh = new DMesh3();
@@ -76,7 +77,7 @@ namespace g3.Tests
             string text = WriteText(wmesh, opts, writer);
             byte[] expected = Encoding.ASCII.GetBytes(text);
             byte[] actual = WriteBinary(wmesh, opts, writer);
-            Assert.Equal(expected, actual);
+            Assert.AreEqual(expected, actual);
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove test folder from library build
- convert `OBJWriterBinaryTests` to NUnit
- add GitHub Actions workflow to run tests
- show build status badge in README

## Testing
- `dotnet test tests/geometry3Sharp.Tests.csproj --no-build --verbosity minimal`
- `dotnet test tests/Geometry3Sharp.Tests/Geometry3Sharp.Tests.csproj --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6846f0133398832b8a976be5adf1ab3a